### PR TITLE
Fixing minor typo in getting started guide

### DIFF
--- a/source/installation-guide.rst
+++ b/source/installation-guide.rst
@@ -1,7 +1,7 @@
 Installation Guide
 ==================
 
-Vala is available on multiple operating systems. Follow the isntallation instructions below for your operating system.
+Vala is available on multiple operating systems. Follow the installation instructions below for your operating system.
 
 Linux
 -----


### PR DESCRIPTION
Just a mini fix for a typo in the getting started guide.