### PR TITLE
Fix tutorials section

### DIFF
--- a/source/tutorials/programming-language/main/03-00-object-oriented-programming/03-06-inheritance.rst
+++ b/source/tutorials/programming-language/main/03-00-object-oriented-programming/03-06-inheritance.rst
@@ -31,11 +31,11 @@ When writing the definition of a class it is possible to exercise precise contro
        }
    }
 
-*data* is an instance data member of *!SuperClass*.  There will be a member of this type in every instance of *!SuperClass*, and it is declared ``private`` so will only be accessible by code that is a part of *!SuperClass*.
+*data* is an instance data member of *SuperClass*.  There will be a member of this type in every instance of *SuperClass*, and it is declared ``private`` so will only be accessible by code that is a part of *SuperClass*.
 
-*protected_method* is an instance method of *!SuperClass*.  You will be able to execute this method only an instance of *!SuperClass* or of one of its subclasses, and only from code that belongs to *!SuperClass* or one of its subclasses - this latter rule being the result of the ``protected`` modifier.
+*protected_method* is an instance method of *SuperClass*.  You will be able to execute this method only an instance of *SuperClass* or of one of its subclasses, and only from code that belongs to *SuperClass* or one of its subclasses - this latter rule being the result of the ``protected`` modifier.
 
-*public_static_method* has two modifiers. The ``static`` modifier means that this method may be called without owning an instance of *!SuperClass* or of one of its subclasses.  As a result, this method will not have access to a ``this`` reference when it is executed.  The ``public`` modifier means that this method can be called from any code, no matter its relationship with *!SuperClass* or its subclasses.
+*public_static_method* has two modifiers. The ``static`` modifier means that this method may be called without owning an instance of *SuperClass* or of one of its subclasses.  As a result, this method will not have access to a ``this`` reference when it is executed.  The ``public`` modifier means that this method can be called from any code, no matter its relationship with *SuperClass* or its subclasses.
 
 Given these definitions, an instance of *SubClass* will contain all three members of *SuperClass*, but will only be able to access the non-private members.  External code will only be able to access the public method.
 

--- a/source/tutorials/programming-language/main/04-00-advanced-features/04-06-multi-threading.rst
+++ b/source/tutorials/programming-language/main/04-00-advanced-features/04-06-multi-threading.rst
@@ -29,7 +29,7 @@ A very simplified example:
 
    Originally, UNIX did not have threads, which means some traditional UNIX APIs are problematic in threaded programs.
 
-   Using this test could check whether the currnt environment supports threads.
+   Using this test could check whether the current environment supports threads.
 
    In most cases, it can be omitted.
 

--- a/source/tutorials/programming-language/main/04-00-advanced-features/04-07-the-main-loop.rst
+++ b/source/tutorials/programming-language/main/04-00-advanced-features/04-07-the-main-loop.rst
@@ -43,7 +43,7 @@ When using GTK+, a main loop will be created automatically, and will be started 
        Gtk.main();
    }
 
-A common requirement in GUI programs is to execute some code as soon as possible, but only when it will not disturb the user. For this, you use !IdleSource instances. These send events to the programs main loop, but request they only be dealt with when there is nothing more important to do.
+A common requirement in GUI programs is to execute some code as soon as possible, but only when it will not disturb the user. For this, you use ``IdleSource`` instances. These send events to the programs main loop, but request they only be dealt with when there is nothing more important to do.
 
 For more information about event loops, `see the GLib and GTK+ documentation <https://docs.gtk.org/glib/main-loop.html>`_.
 

--- a/source/tutorials/programming-language/main/04-00-advanced-features/04-08-asynchronous-methods.rst
+++ b/source/tutorials/programming-language/main/04-00-advanced-features/04-08-asynchronous-methods.rst
@@ -71,7 +71,7 @@ An async method may be called with either of these two forms:
    });
 
 Both forms starts the async method running with the given arguments.
-The second form in addition registers an !AsyncReadyCallback which is
+The second form in addition registers an ``AsyncReadyCallback`` which is
 executed when the method finishes. The callback
 takes a source object, ``obj``, and an instance of GAyncResult, ``res``,
 as arguments. In the callback the ``.end()`` method should be called to receive the
@@ -118,7 +118,7 @@ other code to use to resume the method's execution:
    [... store 'callback' somewhere ...]
    yield;
 
-Some code elsewhere must now call the stored !SourceFunc in order for
+Some code elsewhere must now call the stored ``SourceFunc`` in order for
 the method to be resumed.  This could be done by scheduling the GLib
 main loop to run it:
 

--- a/source/tutorials/programming-language/main/06-00-libraries/06-01-using-libraries.rst
+++ b/source/tutorials/programming-language/main/06-00-libraries/06-01-using-libraries.rst
@@ -7,7 +7,7 @@ Using a library in Vala is largely automated if you use the *valac* compiler.  T
 
    $ valac --pkg gee-1.0 test.vala
 
-This command means your program can use any of the definitions in the *gee-1.0.vapi* file, and also any in any of the packages that *gee-1.0* depends on.  These dependencies would be be listed in *gee-1.0.deps* if there were any.  In this example *valac* is set to build all the way to binary, and will therefore incorporate information from *pkg-config* to link the correct libraries.  This is why the *pkg-config* names are also used for Vala package names.
+This command means your program can use any of the definitions in the *gee-1.0.vapi* file, and also any in any of the packages that *gee-1.0* depends on.  These dependencies would be listed in *gee-1.0.deps* if there were any.  In this example *valac* is set to build all the way to binary, and will therefore incorporate information from *pkg-config* to link the correct libraries.  This is why the *pkg-config* names are also used for Vala package names.
 
 Packages are generally used with namespaces, but they are not technically related.  This means that even though your application is built with reference to the package, you must still include the required ``using`` statements in each file as appropriate, or else use the fully qualified names of all symbols.
 

--- a/source/tutorials/programming-language/main/06-00-libraries/06-04-abi-and-api-design-choices.rst
+++ b/source/tutorials/programming-language/main/06-00-libraries/06-04-abi-and-api-design-choices.rst
@@ -82,7 +82,7 @@ Since GObject Introspection does not handle generics, using them in APIs is harm
 parameters in the constructors of each generic class: one for the GType function, one for the duplication function and
 another for the destruction. These parameters are quite complicated to handle in languages like Python or Javascript.
 
-In addition to this, the properties that expose the generic type parameter will be exposed as ``gpointer``s, which makes it
+In addition to this, the properties that expose the generic type parameter will be exposed as several objects of ``gpointer`` type, which makes it
 even more complicated. Even generic methods like Gee's ``add ()`` will expect a ``gpointer`` in GI, so doing something like 
 this in Python will result in an error, contrary to what you expect.
 

--- a/source/tutorials/programming-language/main/06-00-libraries/06-04-abi-and-api-design-choices.rst
+++ b/source/tutorials/programming-language/main/06-00-libraries/06-04-abi-and-api-design-choices.rst
@@ -82,7 +82,7 @@ Since GObject Introspection does not handle generics, using them in APIs is harm
 parameters in the constructors of each generic class: one for the GType function, one for the duplication function and
 another for the destruction. These parameters are quite complicated to handle in languages like Python or Javascript.
 
-In addition to this, the properties that expose the generic type parameter will be exposed as several objects of ``gpointer`` type, which makes it
+In addition to this, the properties that expose the generic type parameter will be exposed as several objects of the ``gpointer`` type, which makes it
 even more complicated. Even generic methods like Gee's ``add ()`` will expect a ``gpointer`` in GI, so doing something like 
 this in Python will result in an error, contrary to what you expect.
 


### PR DESCRIPTION
Fixed:
- 3.6 Inheritance, 4.7. The Main Loop, 4.8. Asynchronous Methods: remove '!' before class name
- 4.6. Multi-Threading: misspellings
- Other: see changes