### PR TITLE
Make some of the code listings parseable by pygments

### DIFF
--- a/source/developer-guides/bindings/writing-a-vapi-manually/05-00-fundamentals-of-binding-a-c-function/05-01-out-and-reference-parameters-and-return-values.rst
+++ b/source/developer-guides/bindings/writing-a-vapi-manually/05-00-fundamentals-of-binding-a-c-function/05-01-out-and-reference-parameters-and-return-values.rst
@@ -51,10 +51,10 @@ Returning structs is rather different. Because struct's memory is allocated by t
 
 .. code-block:: vala
 
-   public struct Foo { … }
+   public struct Foo { /* … */ }
    public Foo get_foo (int x);
    public void get_foo2 (int x, out Foo f);
-   
+
 .. code-block:: c
 
    void get_foo(int x, foo *ret);
@@ -73,4 +73,3 @@ To return a struct directly, the question mark operator will box it, and make it
    int make_foo(int y, foo **f);
 
 The ownership rules in :doc:`05-02-ownership` apply.
-

--- a/source/developer-guides/bindings/writing-a-vapi-manually/06-00-adding-vala-friendly-semantics/06-03-collections.rst
+++ b/source/developer-guides/bindings/writing-a-vapi-manually/06-00-adding-vala-friendly-semantics/06-03-collections.rst
@@ -77,11 +77,11 @@ For container-like instances, Vala provides syntactic sugar to convert certain o
 
 .. code-block:: vala
 
-   x in a → a.contains (x)
-   a[x, y] → a.get (x, y)
-   a[x, y] = z → a.set (x, y, z);
-   foreach (var x in a) { … } → var x; var i = a.iterator (); while ((x = i.next_value ()) != null) {...}
-   foreach (var x in a) { … } → var i = a.iterator (); while (i.next ()) { var x = i.get (); … }
+   x in a // → a.contains (x)
+   a[x, y] // → a.get (x, y)
+   a[x, y] = z // → a.set (x, y, z);
+   foreach (var x in a) { /* … */ } // → var x; var i = a.iterator (); while ((x = i.next_value ()) != null) { /* … */ }
+   foreach (var x in a) { /* … */ } // → var i = a.iterator (); while (i.next ()) { var x = i.get (); /* … */ }
 
 If appropriate, providing methods that match these prototypes will allow use of the sugar.
 
@@ -90,4 +90,3 @@ If appropriate, providing methods that match these prototypes will allow use of 
 Iterators require an intermediate object to be the holder of the iteration state. That class must implement a next_value function that returns the next value or null if iteration is to stop or it may have a next method with signature ``bool next ()`` that moves to the next element and returns true if there is one and a method ``T get ()`` to retrieve the current value of the iterator. It is rare for a C program to have the interface needed to do this.
 
 Use your best judgement in deciding whether or not to use these conventions. This is modifying the interface, but it does tend to make the resulting interface easier to use.
-

--- a/source/tutorials/programming-language/main/04-00-advanced-features/04-08-asynchronous-methods.rst
+++ b/source/tutorials/programming-language/main/04-00-advanced-features/04-08-asynchronous-methods.rst
@@ -41,7 +41,7 @@ example:
 
    async void display_jpeg(string fnam) {
        // Load JPEG in a background thread and display it when loaded
-       [...]
+       // [...]
    }
 
 
@@ -52,7 +52,7 @@ or:
    async int fetch_webpage(string url, out string text) throws IOError {
        // Fetch a webpage asynchronously and when ready return the
        // HTTP status code and put the page contents in 'text'
-       [...]
+       // [...]
        text = result;
        return status;
    }
@@ -115,7 +115,7 @@ other code to use to resume the method's execution:
 .. code-block:: vala
 
    SourceFunc callback = fetch_webpage.callback;
-   [... store 'callback' somewhere ...]
+   /* … store 'callback' somewhere … */
    yield;
 
 Some code elsewhere must now call the stored ``SourceFunc`` in order for
@@ -169,4 +169,3 @@ Examples
 --------
 
 See `Async Method Samples <https://wiki.gnome.org/Projects/Vala/AsyncSamples>`_ for examples of different ways that async may be used.
-


### PR DESCRIPTION
Fixed some of the code listing so they can be parsed by pygments and highlighted. I mainly looked at ones, that produced errors and doesn't have syntax causing errors in pygments