### PR TITLE
Port Vala for C# Programmers Developer Guide

### DIFF
--- a/source/developer-guides/documentation/vala-for-csharp-devs.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs.rst
@@ -1,0 +1,12 @@
+Vala for C# Programmers
+=======================
+
+These pages describe the syntax differences, not the similarities between Vala
+and C#. It is intended to be a quick introduction to Vala for programmers who
+already know C#.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   vala-for-csharp-devs/*

--- a/source/developer-guides/documentation/vala-for-csharp-devs/01-sources-files.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/01-sources-files.rst
@@ -1,0 +1,6 @@
+Source Files
+============
+
+C#: ``*.cs``
+
+Vala: ``*.cs``

--- a/source/developer-guides/documentation/vala-for-csharp-devs/02-compilation.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/02-compilation.rst
@@ -1,0 +1,33 @@
+Compilation
+===========
+
+C# (.NET / Mono): Compiled to CIL
+
+.. code-block:: bash
+
+	> csc source1.cs source2.cs /out:program.exe
+	$ gmcs source1.cs source2.cs -out:program.exe
+
+Vala: compiled to native code via C code as intermediate code
+
+.. code-block:: bash
+
+	$ valac source1.vala source2.vala -o program
+
+Vala's standard object system is `GObject <https://docs.gtk.org/gobject/>`_,
+compiled Vala libraries are valid C libraries.
+
+Using Packages
+--------------
+
+Mono: `-pkg:`
+
+.. code-block:: bash
+
+   $ gmcs source.cs -pkg:gtk-sharp-2.0 -out:program.exe
+
+Vala: `--pkg`
+
+.. code-block:: bash
+
+   $ valac source.vala --pkg gtk+-2.0 -o program

--- a/source/developer-guides/documentation/vala-for-csharp-devs/03-naming-conventions.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/03-naming-conventions.rst
@@ -1,0 +1,16 @@
+Naming Conventions
+==================
+
+C#
+
+* classes, structs, delegate types: ``CamelCase``
+* methods, properties, events: ``CamelCase``
+* local variables, fields: ``mixedCamelCase`` (sometimes ``lower_case``)
+* constants, enum values: ``CamelCase``
+
+Vala
+
+* classes, structs, delegate types: ``CamelCase``
+* methods, properties, signals: ``lower_case``
+* local variables, fields: ``lower_case``
+* constants, enum values: ``UPPER_CASE``

--- a/source/developer-guides/documentation/vala-for-csharp-devs/04-main-entry-point.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/04-main-entry-point.rst
@@ -1,0 +1,6 @@
+Main Entry Point
+================
+
+C#: ``Main``, must be inside a class
+
+Vala: ``main``, may be outside a class

--- a/source/developer-guides/documentation/vala-for-csharp-devs/05-system-namespace.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/05-system-namespace.rst
@@ -1,0 +1,6 @@
+System Namespace
+================
+
+C#: most important namespace is `System`, not imported by default
+
+Vala: most important namespace is `GLib`, implicitly imported by default

--- a/source/developer-guides/documentation/vala-for-csharp-devs/06-value-types.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/06-value-types.rst
@@ -1,0 +1,10 @@
+Value Types
+===========
+
+* sizes of standard types (``int``, ``long``, ...) are architecture dependent
+* additional Vala types ``int8``, ``int16``, ``int32``, ``int64`` (signed),
+  ``uint8``, ``uint16``, ``uint32``, ``uint64`` (unsigned) with architecture
+  independent guaranteed sizes
+* no ``byte``, ``sbyte`` (use ``uint8``, ``int8`` instead)
+* no ``decimal``
+* C# ``char`` is UCS-2, not Vala's ``char``, but similar to Vala's UCS-4 ``unichar``

--- a/source/developer-guides/documentation/vala-for-csharp-devs/07-verbatim-string-literals.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/07-verbatim-string-literals.rst
@@ -1,0 +1,6 @@
+Verbatim String Literals
+========================
+
+C#: ``@"verbatim string"``
+
+Vala: ``"""verbatim string"""``

--- a/source/developer-guides/documentation/vala-for-csharp-devs/08-documentation-comments.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/08-documentation-comments.rst
@@ -12,7 +12,7 @@ C#:
    /// <param name="bar">...</param>
    /// <returns>...</returns>
 
-Vala: `Valadoc <https://docs.vala.dev/tutorials/programming-language/main/02-00-basics/02-03-comments>`_
+Vala: :doc:`Valadoc </tutorials/programming-language/main/02-00-basics/02-03-comments>`
 comments
 
 .. code-block:: vala

--- a/source/developer-guides/documentation/vala-for-csharp-devs/08-documentation-comments.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/08-documentation-comments.rst
@@ -1,0 +1,26 @@
+Documentation Comments
+======================
+
+C#:
+
+.. code-block:: csharp
+
+   /// <summary>
+   /// Documentation comment
+   /// </summary>
+   /// <param name="foo">...</param>
+   /// <param name="bar">...</param>
+   /// <returns>...</returns>
+
+Vala: `Valadoc <https://docs.vala.dev/tutorials/programming-language/main/02-00-basics/02-03-comments>`_
+comments
+
+.. code-block:: vala
+
+   /**
+    * Documentation comment
+    *
+    * @param foo ...
+    * @param bar ...
+    * @return ...
+   */

--- a/source/developer-guides/documentation/vala-for-csharp-devs/09-object-base-class.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/09-object-base-class.rst
@@ -1,0 +1,24 @@
+Object Base Class
+=================
+
+C#: implicit inheritance from ``object`` (System.Object)
+
+.. code-block:: csharp
+
+   class Foo
+   {
+       // ...
+   }
+
+Vala: no implicit inheritance from ``Object`` (GLib.Object)
+
+.. code-block:: vala
+
+   class Foo : Object {
+       // ...
+   }
+
+What happens if you don't inherit from ``Object``? Nothing terrible. These
+classes will be slightly more lightweight, however, they will lack some features
+such as property change notifications, and your objects won't have a common base
+class. Usually inheriting from ``Object`` is what you want.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/10-method-overloading.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/10-method-overloading.rst
@@ -1,0 +1,45 @@
+Method Overloading
+==================
+
+C#
+
+.. code-block:: csharp
+
+   class Demo
+   {
+       public void Draw(string text) { }
+
+       public void Draw(Shape shape) { }
+
+
+       /* Method overloading + chaining for convenience methods with less arguments */
+
+       void F(int x, string s, double z) { }
+
+       void F(int x, string s)
+       {
+           F(x, s, 0.5);
+       }
+
+       void F(int x)
+       {
+           F(x, "hello");
+       }
+   }
+
+Vala: no method overloading, use different names instead or default values for arguments
+
+.. code-block:: vala
+
+   class Demo : Object {
+
+       public void draw_text (string text) {
+       }
+
+       public void draw_shape (Shape shape) {
+       }
+
+       /* Argument default values, available in Vala, planned for C# 4.0 */
+       void f (int x, string s = "hello", double z = 0.5) {
+       }
+   }

--- a/source/developer-guides/documentation/vala-for-csharp-devs/11-multiple-constructors.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/11-multiple-constructors.rst
@@ -1,0 +1,30 @@
+Multiple Constructors
+=====================
+
+C#: constructor overloading
+
+.. code-block:: csharp
+
+   class Foo
+   {
+       public Foo() { }
+       public Foo(int foo) { }
+       public Foo(string bar) { }
+   }
+
+   new Foo();
+   new Foo(42);
+   new Foo("hello");
+
+Vala: no constructor overloading, named constructors instead
+
+.. code-block:: vala
+
+   class Foo : Object {
+       public Foo () { }
+       public Foo.with_foo (int foo) { }
+       public Foo.from_bar (string bar) { }
+   }
+   new Foo ();
+   new Foo.with_foo (42);
+   new Foo.from_bar ("hello");

--- a/source/developer-guides/documentation/vala-for-csharp-devs/12-constructor-chaining.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/12-constructor-chaining.rst
@@ -1,0 +1,54 @@
+Constructor Chaining
+====================
+
+Base Constructor Chain-Up
+-------------------------
+
+C#
+
+.. code-block:: csharp
+
+   class Foo : Bar
+   {
+       public Foo() : base(42)
+       {
+           // ...
+       }
+   }
+
+Vala: base call inside constructor
+
+.. code-block:: vala
+
+   class Foo : Bar {
+       public Foo () {
+           base (42);
+           // ...
+       }
+   }
+
+Multiple Constructor Chaining
+-----------------------------
+
+C#
+
+.. code-block:: csharp
+
+   class Foo
+   {
+       public Foo() : this("bar") { }
+       public Foo(string bar) { }
+   }
+
+Vala
+
+.. code-block:: vala
+
+   class Foo : Object {
+       public Foo () {
+           this.with_bar ("bar");
+       }
+
+       public Foo.with_bar (string bar) {
+       }
+   }

--- a/source/developer-guides/documentation/vala-for-csharp-devs/13-delegates-lambdas.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/13-delegates-lambdas.rst
@@ -1,0 +1,40 @@
+Delegates / Lambdas
+===================
+
+C#
+
+.. code-block:: csharp
+
+   delegate void DelegateType(string s);
+
+   void Method(string s)
+   {
+       Console.WriteLine(s);
+   }
+
+   // Original style
+   DelegateType d1 = new DelegateType(Method);
+
+   // Direct method assignment
+   DelegateType d2 = Method;
+
+   // C# 2.0 style
+   DelegateType d3 = delegate(string s) => { Console.WriteLine(s); };
+
+   // Lambda Expression with types (C# 3.0)
+   DelegateType d4 = (string s) => { Console.WriteLine(s); };
+
+   // Lambda Expression without types (C# 3.0)
+   DelegateType d5 = (s) => { Console.WriteLine(s); };
+
+Vala: either lambda expression without types or direct method assignment (without ``new ...``), no C# 2.0 style
+
+.. code-block:: vala
+
+   delegate void DelegateType (string s);
+
+   void method (string s) {
+       stdout.printf ("%s\n", s);
+   }
+   DelegateType d1 = method;
+   DelegateType d2 = (s) => { stdout.printf ("%s\n", s); };

--- a/source/developer-guides/documentation/vala-for-csharp-devs/14-events.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/14-events.rst
@@ -1,0 +1,66 @@
+Events
+======
+
+C#: events
+
+.. code-block:: csharp
+
+   using System;
+
+   delegate void SomeEventHandler(object sender, int i);
+
+   class Foo
+   {
+       public event SomeEventHandler SomeEvent;
+
+       public void RaiseSomeEvent(int i)
+       {
+           if (SomeEvent != null) SomeEvent(this, i);
+       }
+   }
+
+   class Demo
+   {
+       static void OnSomeEvent(object sender, int i)
+       {
+           Console.WriteLine("Handler A: " + i);
+       }
+
+       static void Main()
+       {
+           var foo = new Foo();
+           foo.SomeEvent += OnSomeEvent;
+           foo.SomeEvent += (s, i) => Console.WriteLine("Handler B: " + i);
+           foo.RaiseSomeEvent(42);
+           foo.SomeEvent -= OnSomeEvent;
+       }
+   }
+
+Vala: signals
+
+.. code-block:: vala
+
+   class Foo {
+       public signal void some_event (int i);
+   }
+
+   class Demo {
+       static void on_some_event (Foo sender, int i) {
+           stdout.printf ("Handler A: %d\n", i);
+       }
+
+       static void main () {
+           var foo = new Foo ();
+           foo.some_event.connect (on_some_event);
+           foo.some_event.connect ((s, i) => stdout.printf ("Handler B: %d\n", i));
+           foo.some_event (42);
+           foo.some_event.disconnect (on_some_event);
+       }
+   }
+
+No extra delegate declaration, signals can be emitted directly (no null checking
+necessary). Use ``.connect()`` and ``.disconnect()`` instead of ``+=`` and
+``-=``. Both is possible in Vala, however ``+=`` and ``-=`` may become
+deprecated for signal connection.
+
+Signals do not support ``add {}`` and ``remove {}`` blocks.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/15-interfaces.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/15-interfaces.rst
@@ -1,0 +1,73 @@
+Interfaces
+==========
+
+C#
+
+.. code-block:: csharp
+
+   interface IFoo
+   {
+       void Foo(int i);
+       int Bar(string s, double d);
+   }
+
+Vala: ``public abstract`` necessary
+
+.. code-block:: vala
+
+   interface Foo {
+       public abstract void foo (int i);
+       public abstract int bar (string s, double d);
+   }
+
+Why? Because Vala interfaces may have non-abstract methods (i.e. methods with
+implementations) and ``private`` methods! This means Vala interfaces can be used
+as `mixins <https://en.wikipedia.org/wiki/Mixin>`_ (restricted form of multiple
+inheritance).
+
+'I'-prefix not common in GObject world but allowed
+
+C#: interface inheritance
+
+.. code-block:: csharp
+
+   interface IfaceA
+   {
+       void MethodA();
+   }
+
+   interface IfaceB : IfaceA
+   {
+       void MethodB();
+   }
+
+   class Demo : IfaceB
+   {
+       public void MethodA() { }
+       public void MethodB() { }
+   }
+
+Vala: interface prerequisites
+
+.. code-block:: vala
+
+   interface IfaceA : Object {
+       public abstract void method_a ();
+   }
+
+   interface IfaceB : Object, IfaceA {
+       public abstract void method_b ();
+   }
+
+   class Demo : Object, IfaceA, IfaceB {
+       public void method_a () { }
+       public void method_b () { }
+   }
+
+Interfaces in Vala may not inherit from other interfaces, but they may declare
+other interfaces to be prerequisites, which works in roughly the same way.
+Interfaces may also have a class as a prerequisite. This is often used to ensure
+that an instance of an interface is also an ``Object`` subclass. The fact that
+interfaces can not inherit from other interfaces is mostly only a technical
+distinction - in practice Vala's system works the same as C# in this area, but
+with the extra feature of prerequsite classes.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/16-enums.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/16-enums.rst
@@ -1,0 +1,28 @@
+Enums
+=====
+
+Vala enums may have methods:
+
+.. code-block:: vala
+
+   enum Season {
+       SPRING, SUMMER, AUTUMN, WINTER;
+
+       public bool is_hot () {
+           return this == SUMMER;
+       }
+   }
+
+In C# this can only be achieved by extension methods:
+
+.. code-block:: csharp
+
+   enum Season { Spring, Summer, Autumn, Winter }
+
+   static class SeasonExtensions
+   {
+       public static bool IsHot(this Season season)
+       {
+           return season == Season.Summer;
+       }
+   }

--- a/source/developer-guides/documentation/vala-for-csharp-devs/17-struct-initialization.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/17-struct-initialization.rst
@@ -1,0 +1,23 @@
+Struct Initialization
+=====================
+
+C#
+
+.. code-block:: csharp
+
+   var p1 = new Point();
+   var p2 = new Point() { X = 2, Y = 3 };
+   Point p3;
+   p3.X = 2;
+   p3.Y = 3;
+
+Vala: structs are instantiated without using the ``new`` operator.
+
+.. code-block:: vala
+
+   var p1 = Point ();
+   var p2 = Point () { x = 2, y = 3 };
+   Point p3 = { 2, 3 };
+
+Vala structs must be initialized before first use. A Vala struct cannot
+implement interfaces.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/18-multi-dimensional-arrays.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/18-multi-dimensional-arrays.rst
@@ -1,0 +1,6 @@
+Multi-Dimensional Arrays
+========================
+
+C#: both rectangular ``[,]`` and jagged ``[][]`` multi-dimensional arrays
+
+Vala: only rectangular ``[,]`` multi-dimensional arrays, jagged array support planned

--- a/source/developer-guides/documentation/vala-for-csharp-devs/19-nullable-types.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/19-nullable-types.rst
@@ -1,0 +1,21 @@
+Nullable Types
+==============
+
+C#: mark nullable value types
+
+.. code-block:: csharp
+
+   int? i = null;
+
+Vala: mark nullable reference type arguments and return values of methods. They are non-nullable by default!
+
+.. code-block:: vala
+
+   Foo? method (Foo? foo, Bar bar) {
+       return null;
+   }
+
+In this example: ``foo`` and return value may be ``null``, ``bar`` must be
+non-null. Checked at run-time, and to some extent at compile time.
+
+Conclusion: same syntax (``?`` type modifier), different meanings.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/20-code-attributes.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/20-code-attributes.rst
@@ -1,0 +1,8 @@
+Code Attributes
+===============
+
+C#: self-definable
+
+Vala: built into the compiler, mostly used for bindings or
+`D-Bus <https://www.freedesktop.org/wiki/Software/dbus/>`_ interfaces. The most
+prominent attribute for bindings is ``[CCode (...)]``.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/21-properties.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/21-properties.rst
@@ -1,0 +1,122 @@
+Properties
+==========
+
+Default Values for Auto-Implemented Properties
+----------------------------------------------
+
+C#
+
+.. code-block:: csharp
+
+   class Person
+   {
+       public Person()
+       {
+           Name = "Default Name";
+       }
+
+       public string Name { get; set; }
+   }
+
+Vala
+
+.. code-block:: vala
+
+   class Person : Object {
+       public string name { get; set; default = "Default Name"; }
+   }
+
+Setting in constructor works as well, of course.
+
+Property Change Notifications
+-----------------------------
+
+C#: implement ``INotifyPropertyChanged``
+
+.. code-block:: csharp
+
+   using System.ComponentModel;
+
+   class Person : INotifyPropertyChanged
+   {
+       public event PropertyChangedEventHandler PropertyChanged;
+       private string name;
+
+       public string Name
+       {
+           get { return name; }
+           set
+           {
+               name = value;
+               OnPropertyChanged("Name");
+           }
+       }
+
+       protected void OnPropertyChanged(string name)
+       {
+           if (PropertyChanged != null)
+           {
+               PropertyChanged(this, new PropertyChangedEventArgs(name));
+           }
+       }
+
+       static void Main()
+       {
+           var person = new Person();
+           person.PropertyChanged += (sender, e) =>
+           {
+               System.Console.WriteLine("Property '{0}' changed", e.PropertyName);
+           };
+           person.Name = "Foo";
+           person.Name = "Bar";
+       }
+   }
+
+Vala: connect to ``notify`` signal
+
+Every instance of a class derived from ``Object`` has a signal called notify.
+This signal gets emitted every time a property of its object changes.
+
+.. code-block:: vala
+
+   class Person : Object {
+       public string name { get; set; }
+   }
+
+   void main () {
+       var person = new Person ();
+       person.notify.connect ((sender, property) => {
+           stdout.printf ("Property '%s' changed\n", property.name);
+       });
+       person.name = "Foo";
+       person.name = "Bar";
+   }
+
+If you're only interested in change notifications of a single property you can
+use this syntax:
+
+.. code-block:: vala
+
+   person.notify["name"].connect ((sender, property) => {
+       stdout.printf ("name has changed\n");
+   });
+
+Note that in this case you must use the string representation of the property
+name where underscores are replaced by dashes: ``my_property_name`` becomes
+``"my-property-name"`` in this representation, which is the GObject property
+naming convention.
+
+Change notifications can be disabled with a ``CCode`` attribute tag immediately
+before the declaration of the property:
+
+.. code-block:: vala
+
+   class MyObject : Object {
+
+       // notify signal is NOT emitted upon changes in the property
+       [CCode (notify = false)]
+       public int without_notification { get; set; }
+
+       // notify signal is emitted upon changes in the property
+       public int with_notification { get; set; }
+   }

--- a/source/developer-guides/documentation/vala-for-csharp-devs/22-exceptions.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/22-exceptions.rst
@@ -1,0 +1,52 @@
+Exceptions
+==========
+
+C#: unchecked exceptions, class-based
+
+.. code-block:: csharp
+
+   [Serializable()]
+   public class MyException : System.Exception
+   {
+       public MyException() { }
+       public MyException(string message) { }
+       public MyException(string message, System.Exception inner) { }
+       protected MyException(System.Runtime.Serialization.SerializationInfo info,
+                             System.Runtime.Serialization.StreamingContext context) { }
+   }
+
+   void Method()
+   {
+       throw new MyException("not enough foo");
+   }
+   try {
+       Method();
+   } catch (MyException e) {
+       Console.Error.WriteLine(e.Message);
+   }
+
+Vala: checked exceptions, Vala terminology: `errors`, not class-based, no wrapping
+
+.. code-block:: vala
+
+   // error domain with multiple error codes instead of exception class
+   errordomain MyError {
+       FOO,
+       BAR
+   }
+
+   // must be declared in method signature, part of the contract
+   void method () throws MyError {
+       // error domain, error code, error message
+       throw new MyError.FOO ("not enough foo");
+   }
+   // must be catched or propagated, compiler warning if ignored
+   try {
+       method ();
+   } catch (MyError e) {
+       stderr.printf ("Error: %s\n", e.message);
+   }
+
+Although the compiler emits warnings for ignored errors it does not abort the
+compilation process. This allows prototyping without proper error handling and
+will hopefully prevent forgotten empty catch blocks.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/23-argument-checking.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/23-argument-checking.rst
@@ -1,0 +1,46 @@
+Argument Checking
+=================
+
+C#
+
+.. code-block:: csharp
+
+   void Method(double d, int i, Foo foo)
+   {
+       if (d < 0 || d > 1.0)
+           throw new ArgumentOutOfRangeException();
+       if (i < 0 || i > 10)
+           throw new ArgumentOutOfRangeException();
+       if (foo == null)
+           throw new ArgumentNullException();
+       // ...
+   }
+
+Vala: reference type parameters are implicitly checked for ``null`` unless they
+are marked nullable with ``?``, so you don't have to check them manually.
+Methods may have preconditions:
+
+.. code-block:: vala
+
+   void method (double d, int i, Foo foo)
+        requires (d >= 0.0 && d <= 1.0)
+        requires (i >= 0 && i <= 10)
+   {
+       // ...
+   }
+
+Vala additionally supports postcontditions for checking the return value:
+
+.. code-block:: vala
+
+   int square (int i)
+       ensures (result >= 0)
+   {
+       return i * i;
+   }
+
+``result`` is a special variable representing the return value.
+
+Use exceptions (errors) for recoverable runtime errors (database errors, I/O
+errors), use preconditions and assertions (``assert (...)``) for programming
+errors such as illegal arguments.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/24-unsafe-code-and-pointers.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/24-unsafe-code-and-pointers.rst
@@ -1,0 +1,6 @@
+Unsafe Code and Pointers
+========================
+
+C#: must be inside ``unsafe { }`` block
+
+Vala: may be used everywhere. However, be careful nonetheless.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/25-conditional-compilation-directives.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/25-conditional-compilation-directives.rst
@@ -1,0 +1,8 @@
+Conditional Compilation Directives
+==================================
+
+C#: compiler options ``-define:`` or ``-d:``
+
+Vala: compiler options ``--define`` or ``-D``
+
+no ``#define``, ``#undef``, ``#region``, ``#endregion``, ``#line``

--- a/source/developer-guides/documentation/vala-for-csharp-devs/26-resource-disposing.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/26-resource-disposing.rst
@@ -1,0 +1,37 @@
+Resource Disposing
+==================
+
+C#: destructors are non-deterministic, implement ``IDisposable`` instead,
+resource control with ``using``
+
+.. code-block:: csharp
+
+   class MyResource : IDisposable
+   {
+       public void Dispose()
+       {
+           // ...
+       }
+   }
+   /* Usage: */
+   using (var res = new MyResource()) {
+       // ...
+   }
+
+Vala: destructors are deterministic, you can implement the `RAII <https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization>`_
+pattern with destructor
+
+.. code-block:: vala
+
+   class MyResource : Object {
+       ~MyResource () {
+           // ...
+       }
+   }
+   /* Usage: */
+   {
+       var res = new MyResource ();
+       // ...
+   }
+
+Resource is disposed as soon as it goes out of scope.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/27-memory-management.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/27-memory-management.rst
@@ -1,0 +1,13 @@
+Memory Management
+=================
+
+C#: Garbage collection
+
+Vala: Automatic reference counting
+
+This has both `advantages and disadvantages <https://en.wikipedia.org/wiki/Reference_counting#Advantages_and_disadvantages>`_.
+Reference counting is deterministic, but you can form reference cycles in some
+cases. In these cases you must use `weak references <https://en.wikipedia.org/wiki/Weak_reference>`_
+in order to break those cycles. The Vala keyword for this is ``weak``.
+
+See `Vala's Memory Management Explained <https://wiki.gnome.org/Projects/Vala/ReferenceHandling>`_

--- a/source/developer-guides/documentation/vala-for-csharp-devs/28-asynchronous-calls.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/28-asynchronous-calls.rst
@@ -1,0 +1,62 @@
+Asynchronous Calls
+==================
+
+C#
+
+.. code-block:: csharp
+
+   using System;
+
+   class AsyncDemo
+   {
+       delegate int BinaryOperator(int a, int b);
+
+       static int Adder(int a, int b)
+       {
+           return a + b;
+       }
+
+       static void Callback(IAsyncResult r)
+       {
+           BinaryOperator adder = (BinaryOperator) r.AsyncState;
+
+           Console.WriteLine("Addition completed");
+           Console.WriteLine("Result was: {0}", adder.EndInvoke(r));
+       }
+
+       static void Main()
+       {
+           BinaryOperator adder = Adder;
+
+           adder.BeginInvoke(4, 5, Callback, adder);
+
+           /* wait */
+           Console.ReadLine();
+       }
+   }
+
+Vala: built-in support for asynchronous methods (``async``, ``yield``), must be
+compiled with ``--pkg gio-2.0``
+
+.. code-block:: vala
+
+   class AsyncDemo {
+
+       static async int adder (int a, int b) {
+           return a + b;
+       }
+
+       static async void start () {
+           int sum = yield adder (4, 5);
+           stdout.printf ("Addition completed\n");
+           stdout.printf ("Result was: %d\n", sum);
+       }
+
+       static void main () {
+           start ();
+
+           /* wait */
+           var loop = new MainLoop (null, false);
+           loop.run ();
+       }
+   }

--- a/source/developer-guides/documentation/vala-for-csharp-devs/29-static-constructors.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/29-static-constructors.rst
@@ -1,0 +1,31 @@
+Static Constructors
+===================
+
+C#: called before the first instance is created or any static members are
+referenced
+
+.. code-block:: csharp
+
+   class Foo
+   {
+       static Foo()
+       {
+           System.Console.WriteLine("Static constructor invoked.");
+       }
+   }
+
+Vala: ``static construct { }`` block. The first time that a class, or any
+subclass of it, is instantiated, this code is run. It is guaranteed that this
+code will run exactly once in a program where such a class is used.
+
+.. code-block:: vala
+
+   class Foo : Object {
+       static construct {
+           stdout.printf ("Static constructor invoked.\n");
+       }
+   }
+
+Additionally a Vala class can have a class construct { } block. This block will
+be executed once at the first use of its class, and once at the first use of
+each subclass of this class.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/30-external-methods.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/30-external-methods.rst
@@ -1,0 +1,49 @@
+External Methods
+================
+
+C#
+
+.. code-block:: csharp
+
+   using System;
+   using System.Runtime.InteropServices;
+
+   public class MainClass
+   {
+       [DllImport("libfoo.so")]
+       public static extern int SampleMethod(int x);
+
+       static void Main()
+       {
+           Console.WriteLine("SampleMethod() returns {0}", SampleMethod(5));
+       }
+   }
+
+Vala: ``CCode`` attribute, specify original function name (only if it differs
+from the Vala name)
+
+.. code-block:: vala
+
+   public class MainClass : Object {
+
+       [CCode (cname = "SampleMethod")]
+       public static extern int sample_method (int x);
+
+       static void main () {
+           stdout.printf ("sample_method () returns %d\n", sample_method (5));
+       }
+   }
+
+Pass library name to the compiler with ``-X -l...`` (with ``-X`` meaning the next option
+is passed through to the C compiler)
+
+.. code-block:: bash
+
+   $ valac demo.vala -X -lfoo
+
+You can also pass a C source file containing the external method to the Vala
+compiler. This allows for mixed Vala and C source code projects.
+
+.. code-block:: bash
+
+   $ valac demo.vala foo.c

--- a/source/developer-guides/documentation/vala-for-csharp-devs/31-reflection.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/31-reflection.rst
@@ -1,0 +1,53 @@
+Reflection
+==========
+
+Reflection support in Vala is limited. Vala provides run-time type information
+for its data types (``is`` operator, ``foo.get_type ()``, dynamic casting via
+``as`` operator). For example, you can get the names of types, of signals and
+properties of a class and of enum values.
+
+.. code-block:: vala
+
+   class Foo : Object {
+       public int hello { get; set; }
+       public int world { get; set; }
+       public int foo_bar { get; set; }
+
+       public signal void action ();
+       public signal void more_action ();
+   }
+
+   enum Bar {
+       FEE, FIE, FOE, FUM
+   }
+
+   void main () {
+
+       /* Getting type information */
+       Type type = typeof (Foo);
+       stdout.printf ("%s\n", type.name ());
+
+       /* Instantiation from type */
+       Foo foo = (Foo) Object.new (type);
+
+       /* list properties of a class */
+       var obj_class = (ObjectClass) typeof (Foo).class_ref ();
+       var properties = obj_class.list_properties ();
+       foreach (var prop in properties) {
+           stdout.printf ("%s\n", prop.name);
+       }
+
+       /* enum value as string */
+       var enum_class = (EnumClass) typeof (Bar).class_ref ();
+       string name = enum_class.get_value (Bar.FEE).value_name;
+       stdout.printf ("Enum value as string: %s\n", name);
+
+       /* list signals of a class */
+       uint[] ids = Signal.list_ids (typeof (Foo));
+       foreach (uint id in ids) {
+           stdout.printf ("%s\n", Signal.name (id));
+       }
+   }
+
+Libraries built with `GObjectIntrospection <https://gi.readthedocs.io/en/latest/>`_
+support can be fully introspected.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/32-not-available.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/32-not-available.rst
@@ -1,0 +1,17 @@
+Not Available
+=============
+
+* No LINQ (not planned for 1.0, maybe later) there are some [`https://gitlab.com/kosmospredanie/gpseq <https://gitlab.com/kosmospredanie/gpseq>`_]
+* No operator overloading (`vala-list <https://mail.gnome.org/archives/vala-list/2008-July/msg00007.html>`_)
+* No method or constructor overloading (use different method names / named constructors instead, as described above)
+* No extension methods
+* No constraints on generic type parameters (i.e. no ``where``)
+* No generic delegates
+* No conversion operators (i.e. no ``explicit`` and ``implicit``)
+* No ``partial`` classes and methods
+* No ``sealed`` classes (`planned <https://mail.gnome.org/archives/vala-list/2009-September/msg00325.html>`_)
+* No static classes (use nested namespaces instead. Vala supports namespace methods, they are implicitly static)
+* No ``goto``, no labeled statements
+* No constructor initializers
+* No bounds checking for arrays (optional support planned)
+* No ``checked``, ``unchecked``, ``fixed``, ``stackalloc``, ``readonly``

--- a/source/developer-guides/documentation/vala-for-csharp-devs/33-collections.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/33-collections.rst
@@ -1,0 +1,42 @@
+Collections
+===========
+
+C#: ``System.Collections.Generic`` namespace
+
+Vala: ``Gee`` namespace, ``--pkg gee-1.0``, `Libgee <https://wiki.gnome.org/Projects/Libgee>`_
+
+Rough equivalents:
+
+========================== ===
+System.Collections.Generic Gee
+========================== ===
+`Classes`
+Dictionary                 HashMap
+HashSet                    HashSet
+LinkedList                 LinkedList
+List                       ArrayList
+Queue                      LinkedList, PriorityQueue
+SortedDictionary           TreeMap
+Stack                      LinkedList
+`Interfaces`
+ICollection                Collection
+IComparer                  Comparable
+IDictionary                Map
+IEnumerable                Iterable
+IEnumerator                Iterator
+IList                      List
+                           Queue
+                           Deque
+========================== ===
+
+See `Gee Examples <https://wiki.gnome.org/Projects/Vala/GeeSamples>`_
+
+You can access and assign Gee collection items via indexers (e.g.
+``my_map[key]`` is equivalent to ``my_map.get (key)``). Vala supports an ``in``
+operator for collections: ``x in my_collection`` is equivalent to
+``my_collection.contains (x)``. This operator also works with strings, even
+though strings are not collections.
+
+Please note that Libgee checks for errors like the bounds for the index key with
+an ``assert``, and so it won't raise any catchable ``SystemException`` like in
+C#.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/34-indexers.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/34-indexers.rst
@@ -1,0 +1,52 @@
+Indexers
+========
+
+C#: usage of ``this`` keyword to define indexers
+
+.. code-block:: csharp
+
+   class SampleCollection<T>
+   {
+       private T[] arr = new T[100];
+
+       public T this[int i]
+       {
+           get { return arr[i]; }
+           set { arr[i] = value; }
+       }
+   }
+
+   class IndexerDemo
+   {
+       static void Main(string[] args)
+       {
+           var stringCollection = new SampleCollection<string>();
+
+           stringCollection[0] = "Hello, World";
+           System.Console.WriteLine(stringCollection[0]);
+       }
+   }
+
+Vala: implement ``T get(int i)`` and ``void set(int i, T item)`` methods
+
+.. code-block:: vala
+
+   class SampleCollection<T> {
+
+       private T[] arr = new T[100];
+
+       public T get (int i) {
+           return arr[i];
+       }
+
+       public void set (int i, T item) {
+           arr[i] = item;
+       }
+   }
+
+   void main (string[] args) {
+       var string_collection = new SampleCollection<string> ();
+
+       string_collection[0] = "Hello, World";
+       stdout.printf ("%s\n", string_collection[0]);
+   }

--- a/source/developer-guides/documentation/vala-for-csharp-devs/35-io-network-sockets.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/35-io-network-sockets.rst
@@ -1,0 +1,8 @@
+IO, Network Sockets
+===================
+
+C#: System.IO, System.Net.Sockets namespaces
+
+Vala: GLib namespace (imported by default), --pkg gio-2.0, GIO is part of GLib
+
+See `GIO Examples <https://wiki.gnome.org/Projects/Vala/GIOSamples>`_, `GIO Networking Examples <https://wiki.gnome.org/Projects/Vala/GIONetworkingSample>`_

--- a/source/developer-guides/documentation/vala-for-csharp-devs/36-console-input-output.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/36-console-input-output.rst
@@ -1,0 +1,23 @@
+Console Input / Output
+======================
+
+C#
+
+.. code-block:: csharp
+
+   System.Console.WriteLine("Hi!");
+   System.Console.Write("Please enter your name: ");
+   var name = System.Console.ReadLine();
+   System.Console.WriteLine("Welcome, {0}!", name);
+
+Vala
+
+.. code-block:: vala
+
+   stdout.printf ("Hi!\n");
+   stdout.printf ("Please enter your name: ");
+   var name = stdin.read_line ();
+   stdout.printf ("Welcome, %s!\n", name);
+
+``printf`` uses the same `format specifiers <http://en.wikipedia.org/wiki/Printf>`_
+as the C function.

--- a/source/developer-guides/documentation/vala-for-csharp-devs/37-gtk-demo-app.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/37-gtk-demo-app.rst
@@ -1,0 +1,61 @@
+GTK+ Demo App
+=============
+
+C#
+
+.. code-block:: csharp
+
+   using Gtk;
+
+   class Demo : Window
+   {
+       public Demo() : base("This is a window")
+       {
+           SetDefaultSize(250, 200);
+           SetPosition(WindowPosition.Center);
+
+           DeleteEvent += delegate { Application.Quit(); };
+
+           var button = new Button("Click");
+           Add(button);
+           ShowAll();
+       }
+
+       static void Main()
+       {
+           Application.Init();
+           new Demo();
+           Application.Run();
+       }
+   }
+
+Vala
+
+.. code-block:: vala
+
+   using Gtk;
+
+   class Demo : Window {
+
+       public Demo () {
+           this.title = "This is a window";
+           set_default_size (250, 200);
+           set_position (WindowPosition.CENTER);
+
+           this.destroy.connect (Gtk.main_quit);
+
+           var button = new Button.with_label ("Click");
+           add (button);
+           show_all ();
+       }
+
+       static void main (string[] args) {
+           Gtk.init (ref args);
+           new Demo ();
+           Gtk.main ();
+       }
+   }
+
+Vala's GTK+ API is very close to the original GTK+ API. In fact, you're using GTK+ functions directly, only with different syntax.
+
+See `GTK+ Examples <https://docs.vala.dev/tutorials/gui-programming/gtk4-samples>`_

--- a/source/developer-guides/documentation/vala-for-csharp-devs/37-gtk-demo-app.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/37-gtk-demo-app.rst
@@ -58,4 +58,4 @@ Vala
 
 Vala's GTK+ API is very close to the original GTK+ API. In fact, you're using GTK+ functions directly, only with different syntax.
 
-See `GTK+ Examples <https://docs.vala.dev/tutorials/gui-programming/gtk4-samples>`_
+See :doc:`GTK+ Examples </tutorials/gui-programming/gtk4-samples>`

--- a/source/developer-guides/documentation/vala-for-csharp-devs/38-bindings.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/38-bindings.rst
@@ -1,0 +1,30 @@
+Bindings
+========
+
+Mono: runtime bindings (`wrappers`), GAPI tools, `.sources` files with XML syntax
+
+Vala: no runtime bindings necessary, Vala method calls are direct C function
+calls, mapped by `*.vapi` (Vala API) files with Vala syntax, annotated with
+attributes like ``[CCode (...)]``
+
+On Unix systems VAPI files are usually installed in
+
+* `/usr/share/vala/vapi/` or
+* `/usr/local/share/vala/vapi/`
+
+Using a vapi file (e.g. foo-1.0.vapi):
+
+.. code-block:: bash
+
+   $ valac source.vala --pkg foo-1.0
+
+The Vala compiler will additionally look for a corresponding `pkg-config <https://www.freedesktop.org/wiki/Software/pkg-config/>`_
+file (`*.pc`) with the same base name (e.g. `foo-1.0.pc`), usually located in
+
+* `/usr/lib/pkgconfig/` or
+* `/usr/local/lib/pkgconfig/`
+
+and pass its configuration to the C compiler if existing.
+
+VAPI files are either `auto-generated <https://wiki.gnome.org/Projects/Vala/Bindings>`_
+for GObject libraries or hand-written for non-GObject libraries.


### PR DESCRIPTION
Ports 1:1 the old documentation site as #55 calls out. Took the liberty of updating links that 404 and pointed them to something that seemed suitable.

Specifically these

02 Compilation
* 404 link https://library.gnome.org/devel/gobject/stable/pr01.html
* New link https://docs.gtk.org/gobject/tutorial.html

08 Documentation Comments
* 404 link http://live.gnome.org/Valadoc
* New link to Vala docs page https://docs.vala.dev/tutorials/programming-language/main/02-00-basics/02-03-comments. New link appears to be missing documentation about how to document parameters. I understand how it works others may find it useful.

31 Reflection 
* Links to empty page: https://wiki.gnome.org/GObjectIntrospection and https://wiki.gnome.org/Projects/GObjectIntrospection points to reads the docs page
* New link: https://gi.readthedocs.io/en/latest/

32 Not Available
* 404 link https://gitlab.com/kosmospredanie/gpseq|realization
* New link https://gitlab.com/kosmospredanie/gpseq
        
33 Collections
* Empty page http://live.gnome.org/Libgee
* New link to retired gnome wiki page https://wiki.gnome.org/Projects/Libgee
* Links to 404 page https://wiki.gnome.org/Vala/GeeSamples
* New link to retired gnome wiki page https://wiki.gnome.org/Projects/Vala/GeeSamples
        
35 IO, Network Sockets
* Links to 404 page https://live.gnome.org/Vala/GIONetworkingSample
* New link to retired gnome wiki page https://wiki.gnome.org/Projects/Vala/GIONetworkingSample
* Links to 404 page http://live.gnome.org/Vala/GIOSamples
* New link to retired gnome wiki page https://wiki.gnome.org/Projects/Vala/GIOSamples

37 GTK Demo App
* Links to 404 page http://live.gnome.org/Vala/GTKSample
* New link to Vala docs page https://docs.vala.dev/tutorials/gui-programming/gtk4-samples.html

38 Bindings
* Links to 404 page https://live.gnome.org/Vala/Bindings
* New link to retired gnome wiki page https://wiki.gnome.org/Projects/Vala/Bindings