### PR TITLE
Document `o` regex option

### DIFF
--- a/source/tutorials/programming-language/main/05-00-experimental-features/05-02-regular-expression-literals.rst
+++ b/source/tutorials/programming-language/main/05-00-experimental-features/05-02-regular-expression-literals.rst
@@ -34,4 +34,4 @@ The following trailing characters can be used:
 * *m*, the "start of line" and "end of line" constructs match immediately following or immediately before any newline in the string, respectively, as well as at the very start and end.
 * *s*, a dot metacharater *.* in the pattern matches all characters, including newlines. Without it, newlines are excluded.
 * *x*, whitespace data characters in the pattern are totally ignored except when escaped or inside a character class.
-
+* *o*, request JIT compilation of a regular expression. It allows to execute this regex much faster at the cost of extra time taken to compile it. This option is most benificial, when the same compiled pattern is used for matching several times.


### PR DESCRIPTION
From:
https://gitlab.gnome.org/GNOME/vala/-/blob/main/vala/valascanner.vala?ref_type=heads#L152, tho it's not released yet. Probably should be merged after release.