### PR TITLE
Fixing incorrect enum information and add alternatives

### DIFF
--- a/source/developer-guides/bindings/writing-a-vapi-manually/04-00-recognizing-vala-semantics-in-c-code/04-02-enums-and-flags.rst
+++ b/source/developer-guides/bindings/writing-a-vapi-manually/04-00-recognizing-vala-semantics-in-c-code/04-02-enums-and-flags.rst
@@ -65,9 +65,45 @@ There is also a common tendency to use combinable bit patterns. These are conver
    }
 
 
-In Vala, enums and flags may have member functions. In particular, ``strerr``-like functions are best converted to member functions. 
+In Vala, enums and flags may have member functions and properties. In particular, ``strerr``-like functions are best converted to member functions. 
 
-Enums may also inherit, so if one set of flags is a superset of another, but they are logically separate, this can be done using inheritance.
+The default function ``to_string()`` can cause problems if the enum has aliases (the C error ``duplicate case`` will trigger). So to solve this, 
+you can create additional constants after the enum has been declared to add this missing enum aliases.
+
+For example this enum:
+
+.. code-block:: c
+
+   typedef enum {
+       BAR_A,
+       BAR_B,
+       BAR_C,
+       BAR_D,
+       BAR_FIRST = BAR_A,
+       BAR_LAST = BAR_D,
+   } bar_e;
+
+Will become:
+
+.. code-block:: vala
+
+   [CCode (cname = "bar_e", cprefix = "BAR_", has_type_id = false)]
+   public enum Bar {
+       A,
+       B,
+       C;
+
+       [CCode (cname = "BAR_")]
+       public const Bar FIRST;
+
+       [CCode (cname = "BAR_")]
+       public const Bar LAST;
+   }
+
+If one set of flags is a superset of another, but they are logically separate, You can create a different set of enums that refer to the same enum
+or defines.
+
+For example:
 
 .. code-block:: c
 
@@ -80,10 +116,17 @@ Enums may also inherit, so if one set of flags is a superset of another, but the
    /* takes any FOO_ value */
    void do_something_else(int);
 
+Can become this:
+
 .. code-block:: vala
 
    [CCode (cname = "int", cprefix = "FOO_", has_type_id = false)]
    public enum Foo { A, B }
    [CCode (cname = "int", cprefix = "FOO_", has_type_id = false)]
-   public enum FooExtended : Foo { C, D }
+   public enum FooExtended { C, D }
 
+You can then cast one enum to another:
+
+.. code.block:: vala
+
+var foo_enum = (Foo) FooExtended.C;

--- a/source/developer-guides/bindings/writing-a-vapi-manually/04-00-recognizing-vala-semantics-in-c-code/04-02-enums-and-flags.rst
+++ b/source/developer-guides/bindings/writing-a-vapi-manually/04-00-recognizing-vala-semantics-in-c-code/04-02-enums-and-flags.rst
@@ -64,11 +64,51 @@ There is also a common tendency to use combinable bit patterns. These are conver
        CREATE
    }
 
+Supersets
+---------
 
-In Vala, enums and flags may have member functions and properties. In particular, ``strerr``-like functions are best converted to member functions. 
+If one set of enums or flags is a superset of another, but they are logically separate, You can create a different set of enums that refer to the same enum
+or defines.
+
+For example:
+
+.. code-block:: c
+
+   #define FOO_A 1
+   #define FOO_B 2
+   #define FOO_C 3
+   #define FOO_D 4
+   /* takes FOO_A or B only */
+   void do_something(int);
+   /* takes any FOO_ value */
+   void do_something_else(int);
+
+Can become this:
+
+.. code-block:: vala
+
+   [CCode (cname = "int", cprefix = "FOO_", has_type_id = false)]
+   public enum Foo { A, B }
+   [CCode (cname = "int", cprefix = "FOO_", has_type_id = false)]
+   public enum FooExtended { C, D }
+
+You can then cast one enum to another:
+
+.. code-block:: vala
+    
+   var foo_enum = (Foo) FooExtended.C;
+
+Member functions and constants
+------------------------------
+
+In Vala, enums and flags may have member functions and constants.
+In particular, ``strerr``-like functions are best converted to member functions. 
+
+Enum aliases and ``to_string()``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default function ``to_string()`` can cause problems if the enum has aliases (the C error ``duplicate case`` will trigger). So to solve this, 
-you can create additional constants after the enum has been declared to add this missing enum aliases.
+you can create additional constants after the enum has been declared to add the missing enum aliases.
 
 For example this enum:
 
@@ -99,34 +139,3 @@ Will become:
        [CCode (cname = "BAR_")]
        public const Bar LAST;
    }
-
-If one set of flags is a superset of another, but they are logically separate, You can create a different set of enums that refer to the same enum
-or defines.
-
-For example:
-
-.. code-block:: c
-
-   #define FOO_A 1
-   #define FOO_B 2
-   #define FOO_C 3
-   #define FOO_D 4
-   /* takes FOO_A or B only */
-   void do_something(int);
-   /* takes any FOO_ value */
-   void do_something_else(int);
-
-Can become this:
-
-.. code-block:: vala
-
-   [CCode (cname = "int", cprefix = "FOO_", has_type_id = false)]
-   public enum Foo { A, B }
-   [CCode (cname = "int", cprefix = "FOO_", has_type_id = false)]
-   public enum FooExtended { C, D }
-
-You can then cast one enum to another:
-
-.. code.block:: vala
-
-var foo_enum = (Foo) FooExtended.C;


### PR DESCRIPTION
The current page https://docs.vala.dev/developer-guides/bindings/writing-a-vapi-manually/04-00-recognizing-vala-semantics-in-c-code/04-02-enums-and-flags.html

Indicates that an `enum` can inherit.
According to a recent conversation issue in the Vala GitLab, this is incorrect, and `enum` inheritance is not a thing:

https://gitlab.gnome.org/GNOME/vala/-/issues/1595


So I removed this set of code and example, and instead added a valid alternative (just creating a separate `enum` and casting to the original can work).

I also added another `enum` example to deal with aliases, which when you invoke a `to_string ()` method can cause `duplicate case` compiler errors in C, which can be solved via `public const values`. (Explained here https://gitlab.gnome.org/GNOME/vala/-/issues/1596)

Hopefully this is a good addition to the docs :).