### PR TITLE
docs: fix source file extension for vala in 01-sources-files.rst

### DIFF
--- a/source/developer-guides/documentation/vala-for-csharp-devs/01-sources-files.rst
+++ b/source/developer-guides/documentation/vala-for-csharp-devs/01-sources-files.rst
@@ -3,4 +3,4 @@ Source Files
 
 C#: ``*.cs``
 
-Vala: ``*.cs``
+Vala: ``*.vala``


### PR DESCRIPTION
## Description
Currently, the source file in developer guide for c# developers suggests that `.cs` is the source file extension for vala source files rather than `.vala`.  

https://docs.vala.dev/developer-guides/documentation/vala-for-csharp-devs/01-sources-files.html

This changes it to `.vala`.