### PR TITLE
docs: add jetbrains editor support in code-editors-and-ides.rst

### DIFF
--- a/source/tooling/code-editors-and-ides.rst
+++ b/source/tooling/code-editors-and-ides.rst
@@ -82,13 +82,13 @@ Text editors with additional features for handling computer code can be called "
      -
      -
      -
-   * - `IntelliJ IDEA <https://www.jetbrains.com/idea/>`_
-     - Yes
-     -
-     -
-     -
-     -
-     -
+   * - `JetBrain IDEs <https://www.jetbrains.com/ides/>`_
+     - `Yes <https://github.com/Tbusk/vala-jetbrains-plugin>`__
+     - `Yes <https://github.com/Tbusk/vala-jetbrains-plugin>`__
+     - `Yes <https://github.com/Tbusk/vala-jetbrains-plugin>`__
+     - `Yes <https://github.com/Tbusk/vala-jetbrains-plugin>`__
+     - `Yes <https://github.com/Tbusk/vala-jetbrains-plugin>`__
+     - `Yes <https://github.com/Tbusk/vala-jetbrains-plugin>`__
      -
      -
    * - `medit <https://mooedit.sourceforge.net/>`_


### PR DESCRIPTION
## Description
- Adding JetBrains IDEs as supported code editors
- Removing Intellij IDEA support as JetBrains IDEs are now supported and supersedes Intellij IDEA.

Plugin GitHub Repo: 
https://github.com/Tbusk/vala-jetbrains-plugin

JetBrains Marketplace:
https://plugins.jetbrains.com/plugin/27464-vala-language