### PR TITLE
docs: update MSYS2 installation commands for Vala

### DIFF
--- a/source/installation-guide.rst
+++ b/source/installation-guide.rst
@@ -69,9 +69,9 @@ then install vala with the following commands:
 
 .. code-block:: console
 
-   $ pacman -S mingw-w64-x86_64-gcc
-   $ pacman -S mingw-w64-x86_64-pkg-config
-   $ pacman -S mingw-w64-x86_64-vala
+   $ pacman -S mingw-w64-ucrt-x86_64-gcc
+   $ pacman -S mingw-w64-ucrt-x86_64-pkg-config
+   $ pacman -S mingw-w64-ucrt-x86_64-vala
 
 You also need to install all the libraries that you want to use individually.
 


### PR DESCRIPTION
Recommend to install ucrt packages instead of deprecated ones.

See also:
* https://www.msys2.org/news/#2022-10-29-changing-the-default-environment-from-mingw64-to-ucrt64
* https://www.msys2.org/docs/environments/